### PR TITLE
Initial performance improvements

### DIFF
--- a/microscope/find_citations.py
+++ b/microscope/find_citations.py
@@ -2,9 +2,8 @@
 # encoding: utf-8
 from typing import Callable, Iterable, List, Optional, Union
 
-from reporters_db import EDITIONS, VARIATIONS_ONLY
-
 from microscope.helpers import (
+    REPORTER_STRINGS,
     add_defendant,
     add_post_citation,
     disambiguate_reporters,
@@ -46,9 +45,7 @@ def get_citations(
         # CASE 1: Citation token is a reporter (e.g., "U. S.").
         # In this case, first try extracting it as a standard, full citation,
         # and if that fails try extracting it as a short form citation.
-        if citation_token in list(EDITIONS.keys()) + list(
-            VARIATIONS_ONLY.keys()
-        ):
+        if citation_token in REPORTER_STRINGS:
             citation = extract_full_citation(words, i)
             if citation:
                 # CASE 1A: Standard citation found, try to add additional data

--- a/microscope/find_citations.py
+++ b/microscope/find_citations.py
@@ -1,5 +1,4 @@
 import re
-
 from typing import Callable, Iterable, List, Optional, Union
 
 from microscope.helpers import (

--- a/microscope/find_citations.py
+++ b/microscope/find_citations.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
+import re
 from typing import Callable, Iterable, List, Optional, Union
 
 from microscope.helpers import (
@@ -73,7 +74,7 @@ def get_citations(
         # In this case, we're not sure yet what the citation's antecedent is.
         # It could be any of the previous citations above. Thus, like an Id.
         # citation, for safety we won't resolve this reference yet.
-        elif strip_punct(citation_token.lower()) == "supra":
+        elif re.match(r"[^a-z0-9]*supra[^a-z0-9]*$", citation_token.lower()):
             citation = extract_supra_citation(words, i)
 
         # CASE 4: Citation token is a section marker.

--- a/microscope/helpers.py
+++ b/microscope/helpers.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 import re
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 from courts_db import courts
 from reporters_db import EDITIONS, REPORTERS, VARIATIONS_ONLY
@@ -30,6 +30,9 @@ STOP_TOKENS = [
     "granted",
     "dismissed",
 ]
+REPORTER_STRINGS: Set[str] = set(
+    list(EDITIONS.keys()) + list(VARIATIONS_ONLY.keys())
+)
 
 
 def is_scotus_reporter(citation: Citation) -> bool:

--- a/microscope/reporter_tokenizer.py
+++ b/microscope/reporter_tokenizer.py
@@ -7,12 +7,12 @@
 import re
 from typing import List
 
-from reporters_db import EDITIONS, VARIATIONS_ONLY
+from microscope.helpers import REPORTER_STRINGS
 
 # We need to build a REGEX that has all the variations and the reporters in
 # order from longest to shortest.
-REGEX_LIST = list(EDITIONS.keys()) + list(VARIATIONS_ONLY.keys())
-REGEX_LIST.sort(key=len, reverse=True)
+
+REGEX_LIST = sorted(REPORTER_STRINGS, key=len, reverse=True)
 REGEX_STR = "|".join(map(re.escape, REGEX_LIST))
 REPORTER_RE = re.compile(r"(^|\s)(%s)(\s|,)" % REGEX_STR)
 
@@ -37,7 +37,7 @@ def tokenize(text: str) -> List[str]:
     strings = REPORTER_RE.split(text)
     words = []
     for string in strings:
-        if string in list(EDITIONS.keys()) + list(VARIATIONS_ONLY.keys()):
+        if string in REPORTER_STRINGS:
             words.append(string)
         else:
             # Normalize spaces


### PR DESCRIPTION
This is a first quick pass at improving performance, split into three commits from most to least useful. The result is a ~90% runtime reduction (10x faster) on a large test case.

* Cache the set of valid reporter strings in `microscope.helpers.REPORTER_STRINGS`. Reduces runtime by about 2/3.
* Use a simpler regex to check for "supra" strings instead of using `strip_punct()`. Reduces remaining runtime by about 2/3. This is a functional change, as it will match some "`<non-alphanum>supra<non-alphanum>`" strings that the old code wouldn't. I think that's not a big deal in practice though.
  * Also note the supra line still isn't that fast, accounting for 7% of total runtime. In a later refactor I think determining token types might want to live in `tokenize` so it can be done in one pass, both for efficiency in the hyperscan version and for flexibility by swapping tokenizers.
* Simplify the `_tokenize()` function by moving `text = re.sub(" +", " ", text)` to a single call in `tokenize()` and removing a no-op `text = " " + text + " "`. Moving the `re.sub` is a functional change, but I think a correct one. Truth be told this third commit has little impact on performance, but the extra work being done in `_tokenize()` was complicating the analysis and it seemed easier to pull it out.

Following these changes, 75% of runtime is now in the line `strings = REPORTER_RE.split(text)`. I have a few approaches for improving this but they're more invasive so I'll save that for a separate issue.