### PR TITLE
Factor out text cleaning

### DIFF
--- a/microscope/cleaners.py
+++ b/microscope/cleaners.py
@@ -1,0 +1,42 @@
+import re
+from typing import Callable, Dict
+
+import lxml.html
+
+
+def html(html_content: str) -> str:
+    """Given HTML markup, return only text that is visible
+    Adopted from freelawproject/juriscraper/lib/html_utils.py#L163
+
+    :param html_content: The HTML string
+    :return: Text that is visible
+    """
+    html_tree = lxml.html.fromstring(html_content)
+    text = html_tree.xpath(
+        """//text()[normalize-space() and not(
+            parent::style |
+            parent::link |
+            parent::head |
+            parent::script)]"""
+    )
+    return " ".join(text)
+
+
+def whitespace(text: str) -> str:
+    """Collapse multiple spaces into one, and strip whitespace."""
+    text = re.sub(" +", " ", text)
+
+    return text.strip()
+
+
+def underscores(text: str) -> str:
+    """Remove strings of two or more underscores that are common
+    in text extracted from PDFs."""
+    return re.sub(r"__+", "", text)
+
+
+cleaners_lookup: Dict[str, Callable[[str], str]] = {
+    "html": html,
+    "whitespace": whitespace,
+    "underscores": underscores,
+}

--- a/microscope/find_citations.py
+++ b/microscope/find_citations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from typing import List, Optional, Union
+from typing import Callable, Iterable, List, Optional, Union
 
 from reporters_db import EDITIONS, VARIATIONS_ONLY
 
@@ -22,19 +22,20 @@ from microscope.models import (
     SupraCitation,
 )
 from microscope.reporter_tokenizer import tokenize
-from microscope.utils import get_visible_text, strip_punct
+from microscope.utils import clean_text, strip_punct
 
 
 def get_citations(
     text: str,
-    html: bool = True,
     do_post_citation: bool = True,
     do_defendant: bool = True,
     disambiguate: bool = True,
+    clean: Iterable[Union[str, Callable[[str], str]]] = ("whitespace",),
 ) -> List[Union[NonopinionCitation, Citation]]:
     """Main function"""
-    if html:
-        text = get_visible_text(text)
+    if clean:
+        text = clean_text(text, clean)
+
     words = tokenize(text)
     citations: List[Union[Citation, NonopinionCitation]] = []
 

--- a/microscope/reporter_tokenizer.py
+++ b/microscope/reporter_tokenizer.py
@@ -41,19 +41,5 @@ def tokenize(text: str) -> List[str]:
             words.append(string)
         else:
             # Normalize spaces
-            words.extend(_tokenize(string))
+            words.extend(string.strip().split())
     return words
-
-
-def _tokenize(text: str) -> List[str]:
-    # add extra space to make things easier
-    text = " " + text + " "
-
-    # get rid of all the annoying underscores in text from pdfs
-    text = re.sub(r"__+", "", text)
-
-    # reduce excess whitespace
-    text = re.sub(" +", " ", text)
-    text = text.strip()
-
-    return text.split()

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -17,6 +17,23 @@ from microscope.models import (
 
 
 class FindTest(TestCase):
+    def run_test_pairs(self, test_pairs, message):
+        for q, a, *kwargs in test_pairs:
+            print(message % q, end=" ")
+            kwargs = kwargs[0] if kwargs else {}
+            cites_found = get_citations(q, **kwargs)
+            self.assertEqual(
+                cites_found,
+                a,
+                msg="%s\n%s\n\n    !=\n\n%s"
+                % (
+                    q,
+                    ",\n".join([str(cite.__dict__) for cite in cites_found]),
+                    ",\n".join([str(cite.__dict__) for cite in a]),
+                ),
+            )
+            print("✓")
+
     def test_find_citations(self):
         """Can we find and make citation objects from strings?"""
         # fmt: off
@@ -286,20 +303,9 @@ class FindTest(TestCase):
              [],),
         )
         # fmt: on
-        for q, a in test_pairs:
-            print("Testing citation extraction for %s..." % q, end=" ")
-            cites_found = get_citations(q)
-            self.assertEqual(
-                cites_found,
-                a,
-                msg="%s\n%s\n\n    !=\n\n%s"
-                % (
-                    q,
-                    ",\n".join([str(cite.__dict__) for cite in cites_found]),
-                    ",\n".join([str(cite.__dict__) for cite in a]),
-                ),
-            )
-            print("✓")
+        self.run_test_pairs(
+            test_pairs, "Testing citation extraction for %s..."
+        )
 
     def test_find_tc_citations(self):
         """Can we parse tax court citations properly?"""
@@ -354,20 +360,9 @@ class FindTest(TestCase):
                            reporter_found='U.S.')]),
         )
         # fmt: on
-        for q, a in test_pairs:
-            print("Testing citation extraction for %s..." % q, end=" ")
-            cites_found = get_citations(q)
-            self.assertEqual(
-                cites_found,
-                a,
-                msg="%s\n%s\n\n    !=\n\n%s"
-                % (
-                    q,
-                    ",\n".join([str(cite.__dict__) for cite in cites_found]),
-                    ",\n".join([str(cite.__dict__) for cite in a]),
-                ),
-            )
-            print("✓")
+        self.run_test_pairs(
+            test_pairs, "Testing tax court citation extraction for %s..."
+        )
 
     def test_date_in_editions(self):
         test_pairs = [
@@ -478,17 +473,4 @@ class FindTest(TestCase):
             ('1 Johnson 1 (1806)', []),
         ]
         # fmt: on
-        for pair in test_pairs:
-            print("Testing disambiguation for %s..." % pair[0], end=" ")
-            citations = get_citations(pair[0], html=False)
-            self.assertEqual(
-                citations,
-                pair[1],
-                msg="%s\n%s != \n%s"
-                % (
-                    pair[0],
-                    [cite.__dict__ for cite in citations],
-                    [cite.__dict__ for cite in pair[1]],
-                ),
-            )
-            print("✓")
+        self.run_test_pairs(test_pairs, "Testing disambiguation for %s...")

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -215,7 +215,8 @@ class FindTest(TestCase):
             # Test italicized Ibid. citation
             ('<p>before asdf. <i>Ibid.</i></p> <p>foo bar lorem</p>',
              [IdCitation(id_token='Ibid.',
-                         after_tokens=['foo', 'bar', 'lorem'])]),
+                         after_tokens=['foo', 'bar', 'lorem'])],
+             {'clean': ['html', 'whitespace']}),
             # Test Id. citation
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id., at 123. foo bar',
              [FullCitation(plaintiff='foo', defendant='bar', volume=1,
@@ -229,12 +230,14 @@ class FindTest(TestCase):
             ('<p>before asdf. <i>Id.,</i> at 123.</p> <p>foo bar</p>',
              [IdCitation(id_token='Id.,',
                          after_tokens=['at', '123.'],
-                         has_page=True)]),
+                         has_page=True)],
+             {'clean': ['html', 'whitespace']}),
             # Test italicized Id. citation with another HTML tag in the way
             ('<p>before asdf. <i>Id.,</i> at <b>123.</b></p> <p>foo bar</p>',
              [IdCitation(id_token='Id.,',
                          after_tokens=['at', '123.'],
-                         has_page=True)]),
+                         has_page=True)],
+             {'clean': ['html', 'whitespace']}),
             # Test weirder Id. citations (#1344)
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. ¶ 34. foo bar',
              [FullCitation(plaintiff='foo', defendant='bar', volume=1,

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+
+from microscope.utils import clean_text
+
+
+class UtilsTest(TestCase):
+    def test_clean_text(self):
+        test_pairs = (
+            (["whitespace"], "  word  \n  word  ", "word \n word"),
+            (["underscores"], "__word__word_", "wordword_"),
+            (["html"], " <style>ignore</style> <i> word </i> ", " word "),
+            (
+                ["html", "underscores", "whitespace"],
+                " <style>ignore</style> __ <i> word  word </i>",
+                "word word",
+            ),
+        )
+        for steps, text, expected in test_pairs:
+            print(
+                "Testing clean_text for %s" % text.replace("\n", " "), end=" "
+            )
+            result = clean_text(text, steps)
+            self.assertEqual(
+                result,
+                expected,
+            )
+            print("✓")
+
+    def test_clean_text_invalid(self):
+        with self.assertRaises(ValueError):
+            clean_text("foo", ["invalid"])


### PR DESCRIPTION
There's currently a few different text cleaning things happening that I know of:

* html is automatically stripped by default
* tokenizer collapses repeated spaces with `text = re.sub(" +", " ", text)`
* tokenizer removes repeated underscores with 
  ```
      # get rid of all the annoying underscores in text from pdfs
      text = re.sub(r"__+", "", text)
  ```

This stuff seems likely to be caller-specific, e.g. CAP will want different things from CL. I'm offering this PR for discussion as one way to refactor. Here's what it includes:

* Html now defaults to False. I like the idea of including this in the library because it's finicky to get right, but I'd want to opt in if I knew I had HTML.
* Collapsing spaces is a good default, and makes sense as a separate pass before the text goes to tokenize(). Now runs as a separate function behind a flag defaulting to True.
* Remove underscore replacing. This strikes me as specific to a particular text processing pipeline (and could conceivably even cause weirdness when double underscores are used as placeholder page numbers), so better for the caller to handle instead of living in the library.

This PR also includes a little refactor of the test harness to get the tests working with the new html default, so test pairs can have individual kwargs like `html=True`.