### PR TITLE
(cleanup) drop header lines

### DIFF
--- a/microscope/find_citations.py
+++ b/microscope/find_citations.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 from typing import Callable, Iterable, List, Optional, Union
 
 from reporters_db import EDITIONS, VARIATIONS_ONLY

--- a/microscope/find_citations.py
+++ b/microscope/find_citations.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from typing import Callable, Iterable, List, Optional, Union
 
 from reporters_db import EDITIONS, VARIATIONS_ONLY

--- a/microscope/helpers.py
+++ b/microscope/helpers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 import re
 from datetime import datetime
 from typing import Dict, List, Optional, Union

--- a/microscope/helpers.py
+++ b/microscope/helpers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import re
 from datetime import datetime
 from typing import Dict, List, Optional, Union

--- a/microscope/models.py
+++ b/microscope/models.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import re
 
 

--- a/microscope/models.py
+++ b/microscope/models.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 import re
 
 

--- a/microscope/reporter_tokenizer.py
+++ b/microscope/reporter_tokenizer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Loosely adapted from the Natural Language Toolkit: Tokenizers
 # URL: <http://nltk.sourceforge.net>
 

--- a/microscope/reporter_tokenizer.py
+++ b/microscope/reporter_tokenizer.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
-
 # Loosely adapted from the Natural Language Toolkit: Tokenizers
 # URL: <http://nltk.sourceforge.net>
 

--- a/microscope/utils.py
+++ b/microscope/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import re
 from typing import Callable, Iterable, Optional, Union
 

--- a/microscope/utils.py
+++ b/microscope/utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 import re
 from typing import Callable, Iterable, Optional, Union
 

--- a/tests/test_FindTest.py
+++ b/tests/test_FindTest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from datetime import datetime
 from unittest import TestCase
 

--- a/tests/test_TokenizeTest.py
+++ b/tests/test_TokenizeTest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest import TestCase
 
 from microscope.reporter_tokenizer import tokenize

--- a/tests/test_UtilsTest.py
+++ b/tests/test_UtilsTest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from unittest import TestCase
 
 from microscope.utils import clean_text


### PR DESCRIPTION
I believe we don't need file encoding lines in python 3 since the default is utf8, and don't need shebangs for files that don't make sense to mark executable. Just a quick cleanup PR -- no big deal to close if you want to keep these around for whatever reason.